### PR TITLE
Remove from_cidr

### DIFF
--- a/src/ipv4.rs
+++ b/src/ipv4.rs
@@ -26,11 +26,6 @@ impl Ipv4Network {
         }
     }
 
-    #[deprecated(since="0.9.1", note="please use `String::parse()` instead")]
-    fn from_cidr(cidr: &str) -> Result<Ipv4Network, IpNetworkError> {
-        cidr.parse()
-    }
-
     /// Returns an iterator over `Ipv4Network`. Each call to `next` will return the next
     /// `Ipv4Addr` in the given network. `None` will be returned when there are no more
     /// addresses.

--- a/src/ipv6.rs
+++ b/src/ipv6.rs
@@ -28,11 +28,6 @@ impl Ipv6Network {
         }
     }
 
-    #[deprecated(since="0.9.1", note="please use `String::parse()` instead")]
-    fn from_cidr(cidr: &str) -> Result<Ipv6Network, IpNetworkError> {
-        cidr.parse()
-    }
-
     pub fn ip(&self) -> Ipv6Addr {
         self.addr
     }


### PR DESCRIPTION
This has been replaced by a `From<str>` implementation