### PR TITLE
Add PartialOrd and Ord instances for network types.

### DIFF
--- a/src/ipv4.rs
+++ b/src/ipv4.rs
@@ -7,7 +7,7 @@ use common::{IpNetworkError, cidr_parts, parse_prefix, parse_addr};
 const IPV4_BITS: u8 = 32;
 
 /// Represents a network range where the IP addresses are of v4
-#[derive(Debug,Clone,Copy,Hash,PartialEq,Eq)]
+#[derive(Debug,Clone,Copy,Hash,PartialEq,Eq,PartialOrd,Ord)]
 pub struct Ipv4Network {
     addr: Ipv4Addr,
     prefix: u8,

--- a/src/ipv6.rs
+++ b/src/ipv6.rs
@@ -9,7 +9,7 @@ const IPV6_BITS: u8 = 128;
 const IPV6_SEGMENT_BITS: u8 = 16;
 
 /// Represents a network range where the IP addresses are of v6
-#[derive(Debug,Clone,Copy,Hash,PartialEq,Eq)]
+#[derive(Debug,Clone,Copy,Hash,PartialEq,Eq,PartialOrd,Ord)]
 pub struct Ipv6Network {
     addr: Ipv6Addr,
     prefix: u8,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ pub use common::IpNetworkError;
 
 /// Represents a generic network range. This type can have two variants:
 /// the v4 and the v6 case.
-#[derive(Debug,Clone,Copy,Hash,PartialEq,Eq)]
+#[derive(Debug,Clone,Copy,Hash,PartialEq,Eq,PartialOrd,Ord)]
 pub enum IpNetwork {
     V4(Ipv4Network),
     V6(Ipv6Network),


### PR DESCRIPTION
This is required to use IpNetwork type with BTreeSet collection.