### PR TITLE
add From<IpAddr> for IpNetwork

### DIFF
--- a/src/ipv4.rs
+++ b/src/ipv4.rs
@@ -195,6 +195,16 @@ impl FromStr for Ipv4Network {
     }
 }
 
+
+impl From<Ipv4Addr> for Ipv4Network {
+    fn from(a: Ipv4Addr) -> Ipv4Network {
+        Ipv4Network {
+            addr: a,
+            prefix: 32,
+        }
+    }
+}
+
 pub struct Ipv4NetworkIterator {
     next: u64,
     end: u64,
@@ -431,5 +441,12 @@ mod test {
         let mask = Ipv4Addr::new(255, 0, 255, 0);
         let prefix = ipv4_mask_to_prefix(mask);
         assert!(prefix.is_err());
+    }
+
+    #[test]
+    fn ipv4network_from_ipv4addr() {
+        let net = Ipv4Network::from(Ipv4Addr::new(127, 0, 0, 1));
+        let expected = Ipv4Network::new(Ipv4Addr::new(127, 0, 0, 1), 32).unwrap();
+        assert_eq!(net, expected);
     }
 }

--- a/src/ipv6.rs
+++ b/src/ipv6.rs
@@ -172,6 +172,15 @@ impl FromStr for Ipv6Network {
     }
 }
 
+impl From<Ipv6Addr> for Ipv6Network {
+    fn from(a: Ipv6Addr) -> Ipv6Network {
+        Ipv6Network {
+            addr: a,
+            prefix: 128,
+        }
+    }
+}
+
 #[cfg(feature = "ipv6-iterator")]
 pub struct Ipv6NetworkIterator {
     next: u128,
@@ -372,5 +381,12 @@ mod test {
     fn size_v6() {
         let cidr: Ipv6Network = "2001:db8::0/96".parse().unwrap();
         assert_eq!(cidr.size(), 4294967296);
+    }
+
+    #[test]
+    fn ipv6network_from_ipv6addr() {
+        let net = Ipv6Network::from(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1));
+        let expected = Ipv6Network::new(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1), 128).unwrap();
+        assert_eq!(net, expected);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,6 +163,15 @@ impl From<Ipv6Network> for IpNetwork {
     }
 }
 
+impl From<IpAddr> for IpNetwork {
+    fn from(addr: IpAddr) -> IpNetwork {
+        match addr {
+            IpAddr::V4(a) => IpNetwork::V4(Ipv4Network::from(a)),
+            IpAddr::V6(a) => IpNetwork::V6(Ipv6Network::from(a)),
+        }
+    }
+}
+
 impl fmt::Display for IpNetwork {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {


### PR DESCRIPTION
This adds From traits so one can conveniently convert an IpAddr to an IpNetwork containing a single address without checking if it's an IPv4 or IPv6 address.