### PR TITLE
Deserialize from String rather &str for Ipv4Network and Ipv6Network

### DIFF
--- a/src/ipv4.rs
+++ b/src/ipv4.rs
@@ -20,8 +20,8 @@ impl<'de> Deserialize<'de> for Ipv4Network {
     where
         D: Deserializer<'de>,
     {
-        let s = <&str>::deserialize(deserializer)?;
-        Ipv4Network::from_str(s).map_err(de::Error::custom)
+        let s = <String>::deserialize(deserializer)?;
+        Ipv4Network::from_str(&s).map_err(de::Error::custom)
     }
 }
 

--- a/src/ipv6.rs
+++ b/src/ipv6.rs
@@ -22,8 +22,8 @@ impl<'de> Deserialize<'de> for Ipv6Network {
     where
         D: Deserializer<'de>,
     {
-        let s = <&str>::deserialize(deserializer)?;
-        Ipv6Network::from_str(s).map_err(de::Error::custom)
+        let s = <String>::deserialize(deserializer)?;
+        Ipv6Network::from_str(&s).map_err(de::Error::custom)
     }
 }
 


### PR DESCRIPTION
Turns out that `Ipv4Network` and the v6 analogue have the same issues deserializing as `IpNetwork` once had in #87. This PR fixes that.