### PR TITLE
Upgrade to Rust 2018 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["network", "ip", "address"]
 readme = "README.md"
 documentation = "https://docs.rs/ipnetwork/"
 categories = ["network-programming", "os"]
+edition = "2018"
 
 [dependencies]
 clippy = {version = "0.0.302", optional = true}

--- a/benches/parse_bench.rs
+++ b/benches/parse_bench.rs
@@ -1,6 +1,6 @@
 #[macro_use]
 extern crate criterion;
-extern crate ipnetwork;
+
 
 use ipnetwork::{Ipv4Network, Ipv6Network};
 use criterion::Criterion;

--- a/benches/parse_bench.rs
+++ b/benches/parse_bench.rs
@@ -1,10 +1,5 @@
-#[macro_use]
-extern crate criterion;
-
-
+use criterion::{criterion_group, criterion_main, Criterion};
 use ipnetwork::{Ipv4Network, Ipv6Network};
-use criterion::Criterion;
-
 use std::net::{Ipv4Addr, Ipv6Addr};
 
 fn parse_ipv4_benchmark(c: &mut Criterion) {

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,5 +1,4 @@
-use std::error::Error;
-use std::fmt;
+use std::{error::Error, fmt};
 
 /// Represents a bunch of errors that can occur while working with a `IpNetwork`
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/common.rs
+++ b/src/common.rs
@@ -10,7 +10,7 @@ pub enum IpNetworkError {
 }
 
 impl fmt::Display for IpNetworkError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use crate::IpNetworkError::*;
         match *self {
             InvalidAddr(ref s) => write!(f, "invalid address: {}", s),

--- a/src/common.rs
+++ b/src/common.rs
@@ -11,7 +11,7 @@ pub enum IpNetworkError {
 
 impl fmt::Display for IpNetworkError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        use IpNetworkError::*;
+        use crate::IpNetworkError::*;
         match *self {
             InvalidAddr(ref s) => write!(f, "invalid address: {}", s),
             InvalidPrefix => write!(f, "invalid prefix"),
@@ -22,7 +22,7 @@ impl fmt::Display for IpNetworkError {
 
 impl Error for IpNetworkError {
     fn description(&self) -> &str {
-        use IpNetworkError::*;
+        use crate::IpNetworkError::*;
         match *self {
             InvalidAddr(_) => "address is invalid",
             InvalidPrefix => "prefix is invalid",

--- a/src/ipv4.rs
+++ b/src/ipv4.rs
@@ -204,7 +204,7 @@ impl Ipv4Network {
 }
 
 impl fmt::Display for Ipv4Network {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(fmt, "{}/{}", self.ip(), self.prefix())
     }
 }

--- a/src/ipv4.rs
+++ b/src/ipv4.rs
@@ -1,10 +1,6 @@
-use std::fmt;
-use std::net::Ipv4Addr;
-use std::str::FromStr;
-
-use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
-
 use crate::common::{cidr_parts, parse_prefix, IpNetworkError};
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+use std::{fmt, net::Ipv4Addr, str::FromStr};
 
 const IPV4_BITS: u8 = 32;
 

--- a/src/ipv4.rs
+++ b/src/ipv4.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 
-use common::{cidr_parts, parse_prefix, IpNetworkError};
+use crate::common::{cidr_parts, parse_prefix, IpNetworkError};
 
 const IPV4_BITS: u8 = 32;
 

--- a/src/ipv6.rs
+++ b/src/ipv6.rs
@@ -5,7 +5,7 @@ use std::str::FromStr;
 
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 
-use common::{cidr_parts, parse_prefix, IpNetworkError};
+use crate::common::{cidr_parts, parse_prefix, IpNetworkError};
 
 const IPV6_BITS: u8 = 128;
 const IPV6_SEGMENT_BITS: u8 = 16;

--- a/src/ipv6.rs
+++ b/src/ipv6.rs
@@ -1,11 +1,6 @@
-use std::cmp;
-use std::fmt;
-use std::net::Ipv6Addr;
-use std::str::FromStr;
-
-use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
-
 use crate::common::{cidr_parts, parse_prefix, IpNetworkError};
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+use std::{cmp, fmt, net::Ipv6Addr, str::FromStr};
 
 const IPV6_BITS: u8 = 128;
 const IPV6_SEGMENT_BITS: u8 = 16;

--- a/src/ipv6.rs
+++ b/src/ipv6.rs
@@ -243,7 +243,7 @@ impl Iterator for Ipv6NetworkIterator {
 }
 
 impl fmt::Display for Ipv6Network {
-    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, fmt: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(fmt, "{}/{}", self.ip(), self.prefix())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,18 +6,12 @@
 #![crate_type = "lib"]
 #![doc(html_root_url = "https://docs.rs/ipnetwork/0.14.0")]
 
-
-
-use std::fmt;
-use std::net::IpAddr;
+use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+use std::{fmt, net::IpAddr, str::FromStr};
 
 mod common;
 mod ipv4;
 mod ipv6;
-
-use std::str::FromStr;
-
-use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 
 pub use crate::common::IpNetworkError;
 pub use crate::ipv4::{ipv4_mask_to_prefix, Ipv4Network};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 #![crate_type = "lib"]
 #![doc(html_root_url = "https://docs.rs/ipnetwork/0.14.0")]
 
-extern crate serde;
+
 
 use std::fmt;
 use std::net::IpAddr;
@@ -296,7 +296,7 @@ impl From<IpAddr> for IpNetwork {
 }
 
 impl fmt::Display for IpNetwork {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             IpNetwork::V4(net) => net.fmt(f),
             IpNetwork::V6(net) => net.fmt(f),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,9 +19,9 @@ use std::str::FromStr;
 
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 
-pub use common::IpNetworkError;
-pub use ipv4::{ipv4_mask_to_prefix, Ipv4Network};
-pub use ipv6::{ipv6_mask_to_prefix, Ipv6Network};
+pub use crate::common::IpNetworkError;
+pub use crate::ipv4::{ipv4_mask_to_prefix, Ipv4Network};
+pub use crate::ipv6::{ipv6_mask_to_prefix, Ipv6Network};
 
 /// Represents a generic network range. This type can have two variants:
 /// the v4 and the v6 case.

--- a/tests/test_json.rs
+++ b/tests/test_json.rs
@@ -1,16 +1,7 @@
-
-
-
-
-#[macro_use]
-extern crate serde_derive;
-
-
-
 #[cfg(test)]
 mod tests {
-
     use ipnetwork::{IpNetwork, Ipv4Network, Ipv6Network};
+    use serde_derive::{Deserialize, Serialize};
     use std::net::{Ipv4Addr, Ipv6Addr};
 
     #[test]

--- a/tests/test_json.rs
+++ b/tests/test_json.rs
@@ -1,11 +1,11 @@
-extern crate serde;
 
-extern crate serde_json;
+
+
 
 #[macro_use]
 extern crate serde_derive;
 
-extern crate ipnetwork;
+
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
I saw you had an earlier branch for upgrading to Rust 2018. But it seems a bit old, and from when the edition was just in preview. I now went through upgrading the crate and doing some manual import cleanup with the new idioms.

I was actually trying to make the `IpvXNetwork::new` constructors `const fn`s, but I realized `if` statements can't be used in `const fn`s yet, so that failed. So I did this instead :)