### PR TITLE
Use `slice::iter` instead of `into_iter` to avoid future breakage

### DIFF
--- a/src/ipv6.rs
+++ b/src/ipv6.rs
@@ -247,7 +247,7 @@ impl fmt::Display for Ipv6Network {
 /// If the mask is invalid this will return an `IpNetworkError::InvalidPrefix`.
 pub fn ipv6_mask_to_prefix(mask: Ipv6Addr) -> Result<u8, IpNetworkError> {
     let mask = mask.segments();
-    let mut mask_iter = mask.into_iter();
+    let mut mask_iter = mask.iter();
 
     // Count the number of set bits from the start of the address
     let mut prefix = 0;


### PR DESCRIPTION
`an_array.into_iter()` currently just works because of the autoref
feature, which then calls `<[T] as IntoIterator>::into_iter`. But
in the future, arrays will implement `IntoIterator`, too. In order
to avoid problems in the future, the call is replaced by `iter()`
which is shorter and more explicit.

A crater run showed that your crate is affected by a potential future 
change. See https://github.com/rust-lang/rust/pull/65819 for more information.