### PR TITLE
ipnetwork: add netmask constructors

### DIFF
--- a/benches/parse_bench.rs
+++ b/benches/parse_bench.rs
@@ -3,30 +3,40 @@ use ipnetwork::{Ipv4Network, Ipv6Network};
 use std::net::{Ipv4Addr, Ipv6Addr};
 
 fn parse_ipv4_benchmark(c: &mut Criterion) {
-    c.bench_function("parse ipv4", |b| b.iter(|| {
-        "127.1.0.0/24".parse::<Ipv4Network>().unwrap()
-    }));
+    c.bench_function("parse ipv4", |b| {
+        b.iter(|| "127.1.0.0/24".parse::<Ipv4Network>().unwrap())
+    });
 }
 
 fn parse_ipv6_benchmark(c: &mut Criterion) {
-    c.bench_function("parse ipv6", |b| b.iter(|| {
-        "FF01:0:0:17:0:0:0:2/64".parse::<Ipv6Network>().unwrap()
-    }));
+    c.bench_function("parse ipv6", |b| {
+        b.iter(|| "FF01:0:0:17:0:0:0:2/64".parse::<Ipv6Network>().unwrap())
+    });
 }
 
 fn contains_ipv4_benchmark(c: &mut Criterion) {
-    c.bench_function("contains ipv4", |b| b.iter(|| {
-        let cidr = "74.125.227.0/25".parse::<Ipv4Network>().unwrap();
-        cidr.contains(Ipv4Addr::new(74, 125, 227, 4))
-    }));
+    c.bench_function("contains ipv4", |b| {
+        b.iter(|| {
+            let cidr = "74.125.227.0/25".parse::<Ipv4Network>().unwrap();
+            cidr.contains(Ipv4Addr::new(74, 125, 227, 4))
+        })
+    });
 }
 
 fn contains_ipv6_benchmark(c: &mut Criterion) {
-    c.bench_function("contains ipv6", |b| b.iter(|| {
-        let cidr = "FF01:0:0:17:0:0:0:2/65".parse::<Ipv6Network>().unwrap();
-        cidr.contains(Ipv6Addr::new(0xff01, 0, 0, 0x17, 0x7fff, 0, 0, 0x2))
-    }));
+    c.bench_function("contains ipv6", |b| {
+        b.iter(|| {
+            let cidr = "FF01:0:0:17:0:0:0:2/65".parse::<Ipv6Network>().unwrap();
+            cidr.contains(Ipv6Addr::new(0xff01, 0, 0, 0x17, 0x7fff, 0, 0, 0x2))
+        })
+    });
 }
 
-criterion_group!(benches, parse_ipv4_benchmark, parse_ipv6_benchmark, contains_ipv4_benchmark, contains_ipv6_benchmark);
+criterion_group!(
+    benches,
+    parse_ipv4_benchmark,
+    parse_ipv6_benchmark,
+    contains_ipv4_benchmark,
+    contains_ipv6_benchmark
+);
 criterion_main!(benches);

--- a/src/common.rs
+++ b/src/common.rs
@@ -37,11 +37,10 @@ pub fn cidr_parts(cidr: &str) -> Result<(&str, Option<&str>), IpNetworkError> {
         // Error if cidr has multiple slashes
         if prefix[1..].find('/').is_some() {
             return Err(IpNetworkError::InvalidCidrFormat(format!(
-            "CIDR must contain a single '/': {}",
-            cidr
+                "CIDR must contain a single '/': {}",
+                cidr
             )));
-        }
-        else {
+        } else {
             // Handle the case when cidr has exactly one slash
             return Ok((ip, Some(&prefix[1..])));
         }

--- a/src/ipv4.rs
+++ b/src/ipv4.rs
@@ -70,13 +70,9 @@ impl Ipv4Network {
 
     /// Checks if the given `Ipv4Network` is partly contained in other.
     pub fn overlaps(self, other: Ipv4Network) -> bool {
-        other.contains(self.ip()) || (
-            other.contains(self.broadcast()) || (
-                self.contains(other.ip()) || (
-                    self.contains(other.broadcast())
-                )
-            )
-        )
+        other.contains(self.ip())
+            || (other.contains(self.broadcast())
+                || (self.contains(other.ip()) || (self.contains(other.broadcast()))))
     }
 
     /// Returns the mask for this `Ipv4Network`.
@@ -477,14 +473,44 @@ mod test {
     fn test_is_subnet_of() {
         let mut test_cases: HashMap<(Ipv4Network, Ipv4Network), bool> = HashMap::new();
 
-        test_cases.insert(("10.0.0.0/30".parse().unwrap(), "10.0.1.0/24".parse().unwrap()), false);
-        test_cases.insert(("10.0.0.0/30".parse().unwrap(), "10.0.0.0/24".parse().unwrap()), true);
-        test_cases.insert(("10.0.0.0/30".parse().unwrap(), "10.0.1.0/24".parse().unwrap()), false);
-        test_cases.insert(("10.0.1.0/24".parse().unwrap(), "10.0.0.0/30".parse().unwrap()), false);
+        test_cases.insert(
+            (
+                "10.0.0.0/30".parse().unwrap(),
+                "10.0.1.0/24".parse().unwrap(),
+            ),
+            false,
+        );
+        test_cases.insert(
+            (
+                "10.0.0.0/30".parse().unwrap(),
+                "10.0.0.0/24".parse().unwrap(),
+            ),
+            true,
+        );
+        test_cases.insert(
+            (
+                "10.0.0.0/30".parse().unwrap(),
+                "10.0.1.0/24".parse().unwrap(),
+            ),
+            false,
+        );
+        test_cases.insert(
+            (
+                "10.0.1.0/24".parse().unwrap(),
+                "10.0.0.0/30".parse().unwrap(),
+            ),
+            false,
+        );
 
         for (key, val) in test_cases.iter() {
             let (src, dest) = (key.0, key.1);
-            assert_eq!(src.is_subnet_of(dest), *val, "testing with {} and {}", src, dest);
+            assert_eq!(
+                src.is_subnet_of(dest),
+                *val,
+                "testing with {} and {}",
+                src,
+                dest
+            );
         }
     }
 
@@ -492,14 +518,44 @@ mod test {
     fn test_is_supernet_of() {
         let mut test_cases: HashMap<(Ipv4Network, Ipv4Network), bool> = HashMap::new();
 
-        test_cases.insert(("10.0.0.0/30".parse().unwrap(), "10.0.1.0/24".parse().unwrap()), false);
-        test_cases.insert(("10.0.0.0/30".parse().unwrap(), "10.0.0.0/24".parse().unwrap()), false);
-        test_cases.insert(("10.0.0.0/30".parse().unwrap(), "10.0.1.0/24".parse().unwrap()), false);
-        test_cases.insert(("10.0.0.0/24".parse().unwrap(), "10.0.0.0/30".parse().unwrap()), true);
+        test_cases.insert(
+            (
+                "10.0.0.0/30".parse().unwrap(),
+                "10.0.1.0/24".parse().unwrap(),
+            ),
+            false,
+        );
+        test_cases.insert(
+            (
+                "10.0.0.0/30".parse().unwrap(),
+                "10.0.0.0/24".parse().unwrap(),
+            ),
+            false,
+        );
+        test_cases.insert(
+            (
+                "10.0.0.0/30".parse().unwrap(),
+                "10.0.1.0/24".parse().unwrap(),
+            ),
+            false,
+        );
+        test_cases.insert(
+            (
+                "10.0.0.0/24".parse().unwrap(),
+                "10.0.0.0/30".parse().unwrap(),
+            ),
+            true,
+        );
 
         for (key, val) in test_cases.iter() {
             let (src, dest) = (key.0, key.1);
-            assert_eq!(src.is_supernet_of(dest), *val, "testing with {} and {}", src, dest);
+            assert_eq!(
+                src.is_supernet_of(dest),
+                *val,
+                "testing with {} and {}",
+                src,
+                dest
+            );
         }
     }
 

--- a/src/ipv6.rs
+++ b/src/ipv6.rs
@@ -118,13 +118,9 @@ impl Ipv6Network {
 
     /// Checks if the given `Ipv6Network` is partly contained in other.
     pub fn overlaps(self, other: Ipv6Network) -> bool {
-        other.contains(self.ip()) || (
-            other.contains(self.broadcast()) || (
-                self.contains(other.ip()) || (
-                    self.contains(other.broadcast())
-                )
-            )
-        )
+        other.contains(self.ip())
+            || (other.contains(self.broadcast())
+                || (self.contains(other.ip()) || (self.contains(other.broadcast()))))
     }
 
     /// Returns the mask for this `Ipv6Network`.
@@ -459,14 +455,44 @@ mod test {
     fn test_is_subnet_of() {
         let mut test_cases: HashMap<(Ipv6Network, Ipv6Network), bool> = HashMap::new();
 
-        test_cases.insert(("2000:999::/56".parse().unwrap(), "2000:aaa::/48".parse().unwrap()), false);
-        test_cases.insert(("2000:aaa::/56".parse().unwrap(), "2000:aaa::/48".parse().unwrap()), true);
-        test_cases.insert(("2000:bbb::/56".parse().unwrap(), "2000:aaa::/48".parse().unwrap()), false);
-        test_cases.insert(("2000:aaa::/48".parse().unwrap(), "2000:aaa::/56".parse().unwrap()), false);
+        test_cases.insert(
+            (
+                "2000:999::/56".parse().unwrap(),
+                "2000:aaa::/48".parse().unwrap(),
+            ),
+            false,
+        );
+        test_cases.insert(
+            (
+                "2000:aaa::/56".parse().unwrap(),
+                "2000:aaa::/48".parse().unwrap(),
+            ),
+            true,
+        );
+        test_cases.insert(
+            (
+                "2000:bbb::/56".parse().unwrap(),
+                "2000:aaa::/48".parse().unwrap(),
+            ),
+            false,
+        );
+        test_cases.insert(
+            (
+                "2000:aaa::/48".parse().unwrap(),
+                "2000:aaa::/56".parse().unwrap(),
+            ),
+            false,
+        );
 
         for (key, val) in test_cases.iter() {
             let (src, dest) = (key.0, key.1);
-            assert_eq!(src.is_subnet_of(dest), *val, "testing with {} and {}", src, dest);
+            assert_eq!(
+                src.is_subnet_of(dest),
+                *val,
+                "testing with {} and {}",
+                src,
+                dest
+            );
         }
     }
 
@@ -474,14 +500,44 @@ mod test {
     fn test_is_supernet_of() {
         let mut test_cases: HashMap<(Ipv6Network, Ipv6Network), bool> = HashMap::new();
 
-        test_cases.insert(("2000:999::/56".parse().unwrap(), "2000:aaa::/48".parse().unwrap()), false);
-        test_cases.insert(("2000:aaa::/56".parse().unwrap(), "2000:aaa::/48".parse().unwrap()), false);
-        test_cases.insert(("2000:bbb::/56".parse().unwrap(), "2000:aaa::/48".parse().unwrap()), false);
-        test_cases.insert(("2000:aaa::/48".parse().unwrap(), "2000:aaa::/56".parse().unwrap()), true);
+        test_cases.insert(
+            (
+                "2000:999::/56".parse().unwrap(),
+                "2000:aaa::/48".parse().unwrap(),
+            ),
+            false,
+        );
+        test_cases.insert(
+            (
+                "2000:aaa::/56".parse().unwrap(),
+                "2000:aaa::/48".parse().unwrap(),
+            ),
+            false,
+        );
+        test_cases.insert(
+            (
+                "2000:bbb::/56".parse().unwrap(),
+                "2000:aaa::/48".parse().unwrap(),
+            ),
+            false,
+        );
+        test_cases.insert(
+            (
+                "2000:aaa::/48".parse().unwrap(),
+                "2000:aaa::/56".parse().unwrap(),
+            ),
+            true,
+        );
 
         for (key, val) in test_cases.iter() {
             let (src, dest) = (key.0, key.1);
-            assert_eq!(src.is_supernet_of(dest), *val, "testing with {} and {}", src, dest);
+            assert_eq!(
+                src.is_supernet_of(dest),
+                *val,
+                "testing with {} and {}",
+                src,
+                dest
+            );
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,14 @@ impl IpNetwork {
         }
     }
 
+    /// Constructs a new `IpNetwork` from a network address and a network mask.
+    ///
+    /// If the netmask is not valid this will return an `IpNetworkError::InvalidPrefix`.
+    pub fn with_netmask(netaddr: IpAddr, netmask: IpAddr) -> Result<Self, IpNetworkError> {
+        let prefix = ip_mask_to_prefix(netmask)?;
+        Self::new(netaddr, prefix)
+    }
+
     /// Returns the IP part of a given `IpNetwork`
     pub fn ip(&self) -> IpAddr {
         match *self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -313,8 +313,9 @@ mod test {
     fn deserialize_from_serde_json_value() {
         use super::*;
         let network = IpNetwork::from_str("0.0.0.0/0").unwrap();
-        let val: serde_json::value::Value = serde_json::from_str(&serde_json::to_string(&network).unwrap()).unwrap();
-        let _deser: IpNetwork =
-            serde_json::from_value(val).expect("Fails to deserialize from json_value::value::Value");
+        let val: serde_json::value::Value =
+            serde_json::from_str(&serde_json::to_string(&network).unwrap()).unwrap();
+        let _deser: IpNetwork = serde_json::from_value(val)
+            .expect("Fails to deserialize from json_value::value::Value");
     }
 }


### PR DESCRIPTION
This adds constructors to build all network types from a network
address and network mask pair.
It also `rustfmt` the whole project.