### PR TITLE
Make the serde dependency optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ env:
     - FEATURES: default
 
 script:
+  - cargo build --verbose --no-default-features
+  - cargo test --verbose --no-default-features
   - cargo build --verbose
   - cargo test --verbose
   - cargo build --release --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 
 [dependencies]
 clippy = {version = "0.0.302", optional = true}
-serde = ">=0.8.0, <2.0"
+serde = { version = ">=0.8.0, <2.0", optional = true }
 
 [dev-dependencies]
 serde_json = "1.0"
@@ -23,7 +23,7 @@ criterion = "0.3.0"
 travis-ci = { repository = "achanda/ipnetwork" }
 
 [features]
-default = []
+default = ["serde"]
 dev = ["clippy"]
 
 [[bench]]

--- a/src/ipv4.rs
+++ b/src/ipv4.rs
@@ -1,5 +1,4 @@
 use crate::common::{cidr_parts, parse_prefix, IpNetworkError};
-use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use std::{fmt, net::Ipv4Addr, str::FromStr};
 
 const IPV4_BITS: u8 = 32;
@@ -11,20 +10,22 @@ pub struct Ipv4Network {
     prefix: u8,
 }
 
-impl<'de> Deserialize<'de> for Ipv4Network {
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for Ipv4Network {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: Deserializer<'de>,
+        D: serde::Deserializer<'de>,
     {
         let s = <String>::deserialize(deserializer)?;
-        Ipv4Network::from_str(&s).map_err(de::Error::custom)
+        Ipv4Network::from_str(&s).map_err(serde::de::Error::custom)
     }
 }
 
-impl Serialize for Ipv4Network {
+#[cfg(feature = "serde")]
+impl serde::Serialize for Ipv4Network {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: Serializer,
+        S: serde::Serializer,
     {
         serializer.serialize_str(&self.to_string())
     }

--- a/src/ipv6.rs
+++ b/src/ipv6.rs
@@ -1,5 +1,4 @@
 use crate::common::{cidr_parts, parse_prefix, IpNetworkError};
-use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use std::{cmp, fmt, net::Ipv6Addr, str::FromStr};
 
 const IPV6_BITS: u8 = 128;
@@ -12,20 +11,22 @@ pub struct Ipv6Network {
     prefix: u8,
 }
 
-impl<'de> Deserialize<'de> for Ipv6Network {
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for Ipv6Network {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: Deserializer<'de>,
+        D: serde::Deserializer<'de>,
     {
         let s = <String>::deserialize(deserializer)?;
-        Ipv6Network::from_str(&s).map_err(de::Error::custom)
+        Ipv6Network::from_str(&s).map_err(serde::de::Error::custom)
     }
 }
 
-impl Serialize for Ipv6Network {
+#[cfg(feature = "serde")]
+impl serde::Serialize for Ipv6Network {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: Serializer,
+        S: serde::Serializer,
     {
         serializer.serialize_str(&self.to_string())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,6 @@
 #![crate_type = "lib"]
 #![doc(html_root_url = "https://docs.rs/ipnetwork/0.15.1")]
 
-use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 use std::{fmt, net::IpAddr, str::FromStr};
 
 mod common;
@@ -25,20 +24,22 @@ pub enum IpNetwork {
     V6(Ipv6Network),
 }
 
-impl<'de> Deserialize<'de> for IpNetwork {
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for IpNetwork {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: Deserializer<'de>,
+        D: serde::Deserializer<'de>,
     {
         let s = <String>::deserialize(deserializer)?;
-        IpNetwork::from_str(&s).map_err(de::Error::custom)
+        IpNetwork::from_str(&s).map_err(serde::de::Error::custom)
     }
 }
 
-impl Serialize for IpNetwork {
+#[cfg(feature = "serde")]
+impl serde::Serialize for IpNetwork {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
-        S: Serializer,
+        S: serde::Serializer,
     {
         serializer.serialize_str(&self.to_string())
     }
@@ -318,6 +319,7 @@ pub fn ip_mask_to_prefix(mask: IpAddr) -> Result<u8, IpNetworkError> {
 #[cfg(test)]
 mod test {
     #[test]
+    #[cfg(feature = "serde")]
     fn deserialize_from_serde_json_value() {
         use super::*;
         let network = IpNetwork::from_str("0.0.0.0/0").unwrap();

--- a/tests/test_json.rs
+++ b/tests/test_json.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "serde")]
+
 #[cfg(test)]
 mod tests {
     use ipnetwork::{IpNetwork, Ipv4Network, Ipv6Network};


### PR DESCRIPTION
Serde is awesome and supporting serialization for the `IpNetwork` types is really really handy. But it does not have to be mandatory. With cargo features support it's easy to make it optional. This can cut down compile times.

Personally I would probably not have the feature activated by default. But changing that is a breaking change, so it would have to wait until 0.16 if it's something you think we should do at all.