### PR TITLE
Metadata cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,9 +5,9 @@ authors = ["Abhishek Chanda <abhishek.becs@gmail.com>", "Linus Färnstrand <faer
 description = "A library to work with IP CIDRs in Rust, heavily WIP"
 license = "Apache-2.0"
 repository = "https://github.com/achanda/ipnetwork"
-keywords = ["network", "ip", "address"]
+keywords = ["network", "ip", "address", "cidr"]
 readme = "README.md"
-categories = ["network-programming", "os"]
+categories = ["network-programming", "parser-implementations"]
 edition = "2018"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ license = "Apache-2.0"
 repository = "https://github.com/achanda/ipnetwork"
 keywords = ["network", "ip", "address"]
 readme = "README.md"
-documentation = "https://docs.rs/ipnetwork/"
 categories = ["network-programming", "os"]
 edition = "2018"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "ipnetwork"
 version = "0.15.1" # When updating version, also modify html_root_url in the lib.rs
 authors = ["Abhishek Chanda <abhishek.becs@gmail.com>", "Linus Färnstrand <faern@faern.net>"]
-description = "A library to work with IP CIDRs in Rust, heavily WIP"
+description = "A library to work with IP CIDRs in Rust"
 license = "Apache-2.0"
 repository = "https://github.com/achanda/ipnetwork"
 keywords = ["network", "ip", "address", "cidr"]


### PR DESCRIPTION
I made some metadata changes. Let's see if you agree with them.

1. Remove "heavily WIP" from description. This crate has been around for a long time now and is used a lot. The API is already very usable and handy. Just because there will be more breaking releases does not mean the entire crate is in some early work in progress state IMO. A bit more cleanup and API fixes and I rather think we should go 1.0. Such a fundamental library should be able to be "stable". Which in turn does not mean there can never be a 2.0, just that it's ready for general use. Which this already is, by far.

2. Add `cidr` keyword.

3. Remove "os" category. The description of that category on crates.io is "Bindings to operating system-specific APIs.". This crate does not bind to/call any OS APIs.

4. Add "parser-implementation" category. Since this crate implements parsing a specific format (cidr).