### PR TITLE
IpNetwork: add is_subnet_of and is_supernet_of

### DIFF
--- a/src/ipv4.rs
+++ b/src/ipv4.rs
@@ -1,7 +1,7 @@
 use crate::common::{cidr_parts, parse_prefix, IpNetworkError};
 use std::{convert::TryFrom, fmt, net::Ipv4Addr, str::FromStr};
 
-const IPV4_BITS: u8 = 32;
+pub(crate) const IPV4_BITS: u8 = 32;
 
 /// Represents a network range where the IP addresses are of v4
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]

--- a/src/ipv4.rs
+++ b/src/ipv4.rs
@@ -1,5 +1,5 @@
 use crate::common::{cidr_parts, parse_prefix, IpNetworkError};
-use std::{fmt, net::Ipv4Addr, str::FromStr, convert::TryFrom};
+use std::{convert::TryFrom, fmt, net::Ipv4Addr, str::FromStr};
 
 const IPV4_BITS: u8 = 32;
 
@@ -167,6 +167,15 @@ impl Ipv4Network {
         let mask = !(0xffff_ffff as u64 >> self.prefix) as u32;
         let net = u32::from(self.addr) & mask;
         (u32::from(ip) & mask) == net
+    }
+
+    /// Checks if a given `Ipv4Addr` is not only in the given `Ipv4Network`, but that
+    /// it is not a special un-assignable address: the network or the broadcast address.
+    ///
+    /// A special case is made for networks with a prefix of 31 or 32, as per RFC 3021.
+    pub fn is_assignable(self, ip: Ipv4Addr) -> bool {
+        self.contains(ip)
+            && (self.prefix() >= 31 || (ip != self.network() && ip != self.broadcast()))
     }
 
     /// Returns number of possible host addresses in this `Ipv4Network`.

--- a/src/ipv6.rs
+++ b/src/ipv6.rs
@@ -1,7 +1,7 @@
 use crate::common::{cidr_parts, parse_prefix, IpNetworkError};
 use std::{cmp, fmt, net::Ipv6Addr, str::FromStr, convert::TryFrom};
 
-const IPV6_BITS: u8 = 128;
+pub(crate) const IPV6_BITS: u8 = 128;
 const IPV6_SEGMENT_BITS: u8 = 16;
 
 /// Represents a network range where the IP addresses are of v6

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,6 +212,49 @@ impl IpNetwork {
     // variant conversions. Then use that to implement a generic is_subnet_of
     // is_supernet_of, overlaps
 
+
+    /// Checks if the given `IpNetwork` is a subnet of the other.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use std::net::IpAddr;
+    /// use ipnetwork::IpNetwork;
+    ///
+    /// let net1: IpNetwork = "127.0.0.0/24".parse().unwrap();
+    /// let net2: IpNetwork = "127.0.0.0/30".parse().unwrap();
+    /// assert!(net2.is_subnet_of(net1));
+    /// assert!(!net1.is_subnet_of(net2));
+    /// ```
+    pub fn is_subnet_of(&self, other: IpNetwork) -> bool {
+        match (*self, other) {
+            (IpNetwork::V4(net), IpNetwork::V4(other)) => net.is_subnet_of(other),
+            (IpNetwork::V6(net), IpNetwork::V6(other)) => net.is_subnet_of(other),
+            _ => false
+        }
+    }
+
+    /// Checks if the given `Ipv4Network` is a supernet of the other.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use std::net::IpAddr;
+    /// use ipnetwork::IpNetwork;
+    ///
+    /// let net1: IpNetwork = "127.0.0.0/24".parse().unwrap();
+    /// let net2: IpNetwork = "127.0.0.0/30".parse().unwrap();
+    /// assert!(!net2.is_supernet_of(net1));
+    /// assert!(net1.is_supernet_of(net2));
+    /// ```
+    pub fn is_supernet_of(&self, other: IpNetwork) -> bool {
+        match (*self, other) {
+            (IpNetwork::V4(net), IpNetwork::V4(other)) => net.is_supernet_of(other),
+            (IpNetwork::V6(net), IpNetwork::V6(other)) => net.is_supernet_of(other),
+            _ => false
+        }
+    }
+
     /// Checks if a given `IpAddr` is in this `IpNetwork`
     ///
     /// # Examples

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,6 +170,14 @@ impl IpNetwork {
         }
     }
 
+    /// Returns the maximum prefix value for the network.
+    pub fn max_prefix(&self) -> u8 {
+        match *self {
+            IpNetwork::V4(_) => ipv4::IPV4_BITS,
+            IpNetwork::V6(_) => ipv6::IPV6_BITS,
+        }
+    }
+
     /// Returns true if the IP in this `IpNetwork` is a valid IPv4 address,
     /// false if it's a valid IPv6 address.
     ///
@@ -202,10 +210,7 @@ impl IpNetwork {
     /// assert_eq!(v6.is_ipv4(), false);
     ///```
     pub fn is_ipv6(&self) -> bool {
-        match *self {
-            IpNetwork::V4(_) => false,
-            IpNetwork::V6(_) => true,
-        }
+        !self.is_ipv4()
     }
 
     // TODO(abhishek) when TryFrom is stable, implement it for IpNetwork to

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -279,6 +279,18 @@ impl IpNetwork {
         }
     }
 
+    /// Checks if a given `Ipv4Addr` is not only in the given `Ipv4Network`, but that
+    /// it is not a special un-assignable address: the network or the broadcast address.
+    ///
+    /// A special case is made for networks with a prefix of 31 or 32, as per RFC 3021.
+    pub fn is_assignable(&self, ip: IpAddr) -> bool {
+        match (*self, ip) {
+            (IpNetwork::V4(net), IpAddr::V4(ip)) => net.is_assignable(ip),
+            (IpNetwork::V6(net), IpAddr::V6(ip)) => net.contains(ip),
+            _ => false,
+        }
+    }
+
     /// Returns the number of possible host addresses in this `IpAddr`
     ///
     /// # Examples


### PR DESCRIPTION
Very similar to the implementations for `contains()` that's already in the `IpNetwork` enum.