### PR TITLE
Update serde version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,11 @@ categories = ["network-programming", "parser-implementations"]
 edition = "2018"
 
 [dependencies]
-serde = { version = ">=0.8.0, <2.0", optional = true }
+serde = { version = "1", optional = true }
 
 [dev-dependencies]
 serde_json = "1.0"
-serde_derive = ">=0.8.0, <2.0"
+serde_derive = "1"
 criterion = "0.3.0"
 
 [badges]


### PR DESCRIPTION
This crate doesn't actually work with serde 0.8 or 0.9.

Fixes #132 