### PR TITLE
Convert Ipv{4,6}Network::new to const functions

### DIFF
--- a/src/ipv4.rs
+++ b/src/ipv4.rs
@@ -35,7 +35,7 @@ impl Ipv4Network {
     /// Constructs a new `Ipv4Network` from any `Ipv4Addr` and a prefix denoting the network size.
     ///
     /// If the prefix is larger than 32 this will return an `IpNetworkError::InvalidPrefix`.
-    pub fn new(addr: Ipv4Addr, prefix: u8) -> Result<Ipv4Network, IpNetworkError> {
+    pub const fn new(addr: Ipv4Addr, prefix: u8) -> Result<Ipv4Network, IpNetworkError> {
         if prefix > IPV4_BITS {
             Err(IpNetworkError::InvalidPrefix)
         } else {

--- a/src/ipv6.rs
+++ b/src/ipv6.rs
@@ -36,7 +36,7 @@ impl Ipv6Network {
     /// Constructs a new `Ipv6Network` from any `Ipv6Addr` and a prefix denoting the network size.
     ///
     /// If the prefix is larger than 128 this will return an `IpNetworkError::InvalidPrefix`.
-    pub fn new(addr: Ipv6Addr, prefix: u8) -> Result<Ipv6Network, IpNetworkError> {
+    pub const fn new(addr: Ipv6Addr, prefix: u8) -> Result<Ipv6Network, IpNetworkError> {
         if prefix > IPV6_BITS {
             Err(IpNetworkError::InvalidPrefix)
         } else {


### PR DESCRIPTION
IpNetwork::new cannot be const since it is not supported with the ?
operator

Closes #111