### PR TITLE
Always inline the contains function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ serde = { version = "1", optional = true }
 [dev-dependencies]
 serde_json = "1.0"
 serde_derive = "1"
-criterion = "0.3.0"
+criterion = {version = "0.3.4", features= ["html_reports"]}
 
 [badges]
 travis-ci = { repository = "achanda/ipnetwork" }

--- a/src/ipv4.rs
+++ b/src/ipv4.rs
@@ -163,6 +163,7 @@ impl Ipv4Network {
     /// assert!(net.contains(Ipv4Addr::new(127, 0, 0, 70)));
     /// assert!(!net.contains(Ipv4Addr::new(127, 0, 1, 70)));
     /// ```
+    #[inline]
     pub fn contains(self, ip: Ipv4Addr) -> bool {
         let mask = !(0xffff_ffff as u64 >> self.prefix) as u32;
         let net = u32::from(self.addr) & mask;

--- a/src/ipv6.rs
+++ b/src/ipv6.rs
@@ -174,6 +174,7 @@ impl Ipv6Network {
     /// assert!(net.contains(Ipv6Addr::new(0xff01, 0, 0, 0, 0, 0, 0, 0x1)));
     /// assert!(!net.contains(Ipv6Addr::new(0xffff, 0, 0, 0, 0, 0, 0, 0x1)));
     /// ```
+    #[inline]
     pub fn contains(&self, ip: Ipv6Addr) -> bool {
         let a = self.addr.segments();
         let b = ip.segments();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -228,6 +228,7 @@ impl IpNetwork {
     /// assert!(!net.contains(ip2));
     /// assert!(!net.contains(ip4));
     /// ```
+    #[inline]
     pub fn contains(&self, ip: IpAddr) -> bool {
         match (*self, ip) {
             (IpNetwork::V4(net), IpAddr::V4(ip)) => net.contains(ip),


### PR DESCRIPTION
This function is commonly called in a loop (or iterator). Inlining it
makes it run faster, which is beneficial in this case.