### PR TITLE
Remove useless allocation when serializing

### DIFF
--- a/src/ipv4.rs
+++ b/src/ipv4.rs
@@ -27,7 +27,7 @@ impl serde::Serialize for Ipv4Network {
     where
         S: serde::Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        serializer.collect_str(self)
     }
 }
 

--- a/src/ipv6.rs
+++ b/src/ipv6.rs
@@ -28,7 +28,7 @@ impl serde::Serialize for Ipv6Network {
     where
         S: serde::Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        serializer.collect_str(self)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@ impl serde::Serialize for IpNetwork {
     where
         S: serde::Serializer,
     {
-        serializer.serialize_str(&self.to_string())
+        serializer.collect_str(self)
     }
 }
 


### PR DESCRIPTION
Replaces `Serializer::serialize_str` with [`Serializer::collect_str`](https://docs.rs/serde/latest/serde/trait.Serializer.html#method.collect_str), which serializes the output of the `Display` implementation without going through the extra allocation, if the `Serializer` supports it. For example the `serde_json::Serializer` [supports it](https://docs.rs/serde_json/latest/src/serde_json/ser.rs.html#445-496)