### PR TITLE
[#153] Add optional JSONSchema implementation for IpNetwork

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2021"
 
 [dependencies]
 serde = { version = "1", optional = true }
+schemars = { version = "0.8.10", optional = true }
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/src/ipv4.rs
+++ b/src/ipv4.rs
@@ -5,6 +5,7 @@ const IPV4_BITS: u8 = 32;
 
 /// Represents a network range where the IP addresses are of v4
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Ipv4Network {
     addr: Ipv4Addr,
     prefix: u8,

--- a/src/ipv6.rs
+++ b/src/ipv6.rs
@@ -6,6 +6,7 @@ const IPV6_SEGMENT_BITS: u8 = 16;
 
 /// Represents a network range where the IP addresses are of v6
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub struct Ipv6Network {
     addr: Ipv6Addr,
     prefix: u8,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ pub use crate::ipv6::{ipv6_mask_to_prefix, Ipv6Network};
 /// Represents a generic network range. This type can have two variants:
 /// the v4 and the v6 case.
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
+#[cfg_attr(feature = "schemars", derive(schemars::JsonSchema))]
 pub enum IpNetwork {
     V4(Ipv4Network),
     V6(Ipv6Network),


### PR DESCRIPTION
# Description
Add  a `JsonSchema` implementation for `IpNetwork`.

## Solution
Derive implementation via `schemars`. Add corresponding
feature to the crate.

## Related Issues
Fixes #153 