### PR TITLE
`is_subnet_of` fix

### DIFF
--- a/src/ipv4.rs
+++ b/src/ipv4.rs
@@ -80,7 +80,7 @@ impl Ipv4Network {
 
     /// Checks if the given `Ipv4Network` is a subnet of the other.
     pub fn is_subnet_of(self, other: Ipv4Network) -> bool {
-        other.ip() <= self.ip() && other.broadcast() >= self.broadcast()
+        other.network() <= self.network() && other.broadcast() >= self.broadcast()
     }
 
     /// Checks if the given `Ipv4Network` is a supernet of the other.

--- a/src/ipv6.rs
+++ b/src/ipv6.rs
@@ -122,7 +122,7 @@ impl Ipv6Network {
 
     /// Checks if the given `Ipv6Network` is a subnet of the other.
     pub fn is_subnet_of(self, other: Ipv6Network) -> bool {
-        other.ip() <= self.ip() && other.broadcast() >= self.broadcast()
+        other.network() <= self.network() && other.broadcast() >= self.broadcast()
     }
 
     /// Checks if the given `Ipv6Network` is a supernet of the other.


### PR DESCRIPTION
Was broken if the supernet was not the network address.

- Supersedes(?) #118.

@Barre did not reply for three years, thus this renewed PR.