### PR TITLE
Add const unsafe `new_unchecked` to `Ipv4Network` & `Ipv6Network`

### DIFF
--- a/src/ipv4.rs
+++ b/src/ipv4.rs
@@ -369,6 +369,14 @@ mod test {
     }
 
     #[test]
+    fn create_unchecked_v4() {
+        let cidr = unsafe { Ipv4Network::new_unchecked(Ipv4Addr::new(77, 88, 21, 11), 24) };
+        assert_eq!(cidr.prefix(), 24);
+        let cidr = unsafe { Ipv4Network::new_unchecked(Ipv4Addr::new(0, 0, 0, 0), 33) };
+        assert_eq!(cidr.prefix(), 33);
+    }
+
+    #[test]
     fn parse_v4_24bit() {
         let cidr: Ipv4Network = "127.1.0.0/24".parse().unwrap();
         assert_eq!(cidr.ip(), Ipv4Addr::new(127, 1, 0, 0));

--- a/src/ipv4.rs
+++ b/src/ipv4.rs
@@ -74,6 +74,12 @@ impl Ipv4Network {
         }
     }
 
+    /// Constructs without checking prefix a new `Ipv4Network` from any `Ipv4Addr,
+    /// and a prefix denoting the network size.
+    pub const unsafe fn new_unchecked(addr: Ipv4Addr, prefix: u8) -> Ipv4Network {
+        Ipv4Network { addr, prefix }
+    }
+
     /// Constructs a new `Ipv4Network` from a network address and a network mask.
     ///
     /// If the netmask is not valid this will return an `IpNetworkError::InvalidPrefix`.

--- a/src/ipv6.rs
+++ b/src/ipv6.rs
@@ -85,6 +85,12 @@ impl Ipv6Network {
         }
     }
 
+    /// Constructs without checking prefix a new `Ipv6Network` from any `Ipv6Addr,
+    /// and a prefix denoting the network size.
+    pub const unsafe fn new_unchecked(addr: Ipv6Addr, prefix: u8) -> Ipv6Network {
+        Ipv6Network { addr, prefix }
+    }
+
     /// Constructs a new `Ipv6Network` from a network address and a network mask.
     ///
     /// If the netmask is not valid this will return an `IpNetworkError::InvalidPrefix`.

--- a/src/ipv6.rs
+++ b/src/ipv6.rs
@@ -417,6 +417,15 @@ mod test {
     }
 
     #[test]
+    fn create_unchecked_v6() {
+        let cidr = unsafe { Ipv6Network::new_unchecked(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1), 24) };
+        assert_eq!(cidr.prefix(), 24);
+        let cidr =
+            unsafe { Ipv6Network::new_unchecked(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1), 129) };
+        assert_eq!(cidr.prefix(), 129);
+    }
+
+    #[test]
     fn parse_v6() {
         let cidr: Ipv6Network = "::1/0".parse().unwrap();
         assert_eq!(cidr.ip(), Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,6 @@
 #![crate_type = "lib"]
 #![deny(
     missing_debug_implementations,
-    unsafe_code,
     unused_extern_crates,
     unused_import_braces
 )]


### PR DESCRIPTION
Hello 😃 

I've encountered a problem using your crate, when I want to define an `&[Ipv4Network]`, I'm not able to get the result, `unwrap()` is not marked as const. One of the solutions I've found would be to introduce two new `new_unchecked` functions for `Ipv4Network` and `Ipv6Network`. This would make it possible to:

```rust
const TEST: &[Ipv4Network] = unsafe {
    &[
        Ipv4Network::new_unchecked(Ipv4Addr::new(127, 0, 0, 0), 8),
        Ipv4Network::new_unchecked(Ipv4Addr::new(10, 0, 0, 0), 8),
    ]
};
```