### PR TITLE
Make the serde feature opt-in instead of opt-out

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,10 @@ travis-ci = { repository = "achanda/ipnetwork" }
 maintenance = { status = "passively-maintained" }
 
 [features]
-default = ["serde"]
+# Keep optional dependencies out of the default features.
+# Since most people add a dependency without `default-features = false` they involuntarily
+# pull in unused dependencies.
+default = []
 
 [[bench]]
 name = "parse_bench"


### PR DESCRIPTION
Like what I said in my earlier PR where I made the serde feature optional (#109): Having dependencies be optional but pulled in by default is often negative. Most people add dependencies without checking their features or optional dependencies too carefully. This leads to them pulling in transitive dependencies they likely don't need.

I can opt out of the serde dependency, sure. But! Now I want to try out the [`const-addrs`](https://crates.io/crates/const-addrs) crate to easily create IP types from macros with compile time validation. This crate depends on `ipnetwork` without opting out of the default features. This means that I now get `serde` as a transitive dependency, even though I really don't need `serde` for anything. It's a rather large dependency to compile for no real use.