### PR TITLE
Replace `Ipv{4,6}Network::new_unchecked` with `Ipv{4,6}Network::new_checked`

### DIFF
--- a/src/ipv4.rs
+++ b/src/ipv4.rs
@@ -89,8 +89,8 @@ impl Ipv4Network {
     /// const ADDR: Ipv4Addr = Ipv4Addr::new(192, 168, 1, 1);
     ///
     /// // Okay!
-    /// const NETWORK: Option<Ipv4Network> = Ipv4Network::new_checked(ADDR, PREFIX);
-    /// assert_eq!(NETWORK.unwrap().prefix(), PREFIX);
+    /// const NETWORK: Ipv4Network = Ipv4Network::new_checked(ADDR, PREFIX).unwrap();
+    /// assert_eq!(NETWORK.prefix(), PREFIX);
     /// ```
     ///
     /// ```should_panic

--- a/src/ipv4.rs
+++ b/src/ipv4.rs
@@ -67,19 +67,17 @@ impl Ipv4Network {
     ///
     /// If the prefix is larger than 32 this will return an `IpNetworkError::InvalidPrefix`.
     pub const fn new(addr: Ipv4Addr, prefix: u8) -> Result<Ipv4Network, IpNetworkError> {
-        if prefix > IPV4_BITS {
-            Err(IpNetworkError::InvalidPrefix)
-        } else {
-            Ok(Ipv4Network { addr, prefix })
+        match Ipv4Network::new_checked(addr, prefix) {
+            Some(a) => Ok(a),
+            None => Err(IpNetworkError::InvalidPrefix),
         }
     }
 
-    /// Constructs without checking prefix a new `Ipv4Network` from any `Ipv4Addr,
-    /// and a prefix denoting the network size.
+    /// Constructs a new `Ipv4Network` from any `Ipv4Addr`, and a prefix denoting the network size.
     ///
-    /// # Safety
-    ///
-    /// The caller must ensure that the prefix is less than or equal to 32.
+    /// If the prefix is larger than 32 this will return `None`. This is useful in const contexts,
+    /// where [`Option::unwrap`] may be called to trigger a compile-time error in case the prefix
+    /// is an unexpected value.
     ///
     /// # Examples
     ///
@@ -87,14 +85,30 @@ impl Ipv4Network {
     /// use std::net::Ipv4Addr;
     /// use ipnetwork::Ipv4Network;
     ///
-    /// let prefix = 24;
-    /// let addr = Ipv4Addr::new(192, 168, 1, 1);
+    /// const PREFIX: u8 = 24;
+    /// const ADDR: Ipv4Addr = Ipv4Addr::new(192, 168, 1, 1);
     ///
-    /// debug_assert!(prefix <= 32);
-    /// let network = unsafe { Ipv4Network::new_unchecked(addr, prefix) };
+    /// // Okay!
+    /// const NETWORK: Ipv4Network = Ipv4Network::new_checked(ADDR, PREFIX).unwrap();
     /// ```
-    pub const unsafe fn new_unchecked(addr: Ipv4Addr, prefix: u8) -> Ipv4Network {
-        Ipv4Network { addr, prefix }
+    ///
+    /// ```
+    /// use std::net::Ipv4Addr;
+    /// use ipnetwork::Ipv4Network;
+    ///
+    /// // Prefix is greater than 32.
+    /// const PREFIX: u8 = 32 + 1;
+    /// const ADDR: Ipv4Addr = Ipv4Addr::new(192, 168, 1, 1);
+    ///
+    /// // Unwrap to get a compile-time error!
+    /// assert!(Ipv4Network::new_checked(ADDR, PREFIX).is_none());
+    /// ```
+    pub const fn new_checked(addr: Ipv4Addr, prefix: u8) -> Option<Ipv4Network> {
+        if prefix > IPV4_BITS {
+            None
+        } else {
+            Some(Ipv4Network { addr, prefix })
+        }
     }
 
     /// Constructs a new `Ipv4Network` from a network address and a network mask.
@@ -396,11 +410,15 @@ mod test {
     }
 
     #[test]
-    fn create_unchecked_v4() {
-        let cidr = unsafe { Ipv4Network::new_unchecked(Ipv4Addr::new(77, 88, 21, 11), 24) };
+    fn create_checked_v4() {
+        let cidr = Ipv4Network::new_checked(Ipv4Addr::new(77, 88, 21, 11), 24).unwrap();
         assert_eq!(cidr.prefix(), 24);
-        let cidr = unsafe { Ipv4Network::new_unchecked(Ipv4Addr::new(0, 0, 0, 0), 33) };
-        assert_eq!(cidr.prefix(), 33);
+    }
+
+    #[test]
+    #[should_panic]
+    fn try_create_invalid_checked_v4() {
+        Ipv4Network::new_checked(Ipv4Addr::new(0, 0, 0, 0), 33).unwrap();
     }
 
     #[test]

--- a/src/ipv4.rs
+++ b/src/ipv4.rs
@@ -89,10 +89,11 @@ impl Ipv4Network {
     /// const ADDR: Ipv4Addr = Ipv4Addr::new(192, 168, 1, 1);
     ///
     /// // Okay!
-    /// const NETWORK: Ipv4Network = Ipv4Network::new_checked(ADDR, PREFIX).unwrap();
+    /// const NETWORK: Option<Ipv4Network> = Ipv4Network::new_checked(ADDR, PREFIX);
+    /// assert_eq!(NETWORK.unwrap().prefix(), PREFIX);
     /// ```
     ///
-    /// ```
+    /// ```should_panic
     /// use std::net::Ipv4Addr;
     /// use ipnetwork::Ipv4Network;
     ///
@@ -100,8 +101,9 @@ impl Ipv4Network {
     /// const PREFIX: u8 = 32 + 1;
     /// const ADDR: Ipv4Addr = Ipv4Addr::new(192, 168, 1, 1);
     ///
-    /// // Unwrap to get a compile-time error!
-    /// assert!(Ipv4Network::new_checked(ADDR, PREFIX).is_none());
+    /// // This fails!
+    /// const NETWORK: Option<Ipv4Network> = Ipv4Network::new_checked(ADDR, PREFIX);
+    /// assert_eq!(NETWORK.unwrap().prefix(), PREFIX);
     /// ```
     pub const fn new_checked(addr: Ipv4Addr, prefix: u8) -> Option<Ipv4Network> {
         if prefix > IPV4_BITS {

--- a/src/ipv6.rs
+++ b/src/ipv6.rs
@@ -100,10 +100,11 @@ impl Ipv6Network {
     /// const ADDR: Ipv6Addr = Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 0);
     ///
     /// // Okay!
-    /// const NETWORK: Ipv6Network = Ipv6Network::new_checked(ADDR, PREFIX).unwrap();
+    /// const NETWORK: Option<Ipv6Network> = Ipv6Network::new_checked(ADDR, PREFIX);
+    /// assert_eq!(NETWORK.unwrap().prefix(), PREFIX);
     /// ```
     ///
-    /// ```
+    /// ```should_panic
     /// use std::net::Ipv6Addr;
     /// use ipnetwork::Ipv6Network;
     ///
@@ -111,8 +112,9 @@ impl Ipv6Network {
     /// const PREFIX: u8 = 128 + 1;
     /// const ADDR: Ipv6Addr = Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 0);
     ///
-    /// // Unwrap to get a compile-time error!
-    /// assert!(Ipv6Network::new_checked(ADDR, PREFIX).is_none());
+    /// // This fails!
+    /// const NETWORK: Option<Ipv6Network> = Ipv6Network::new_checked(ADDR, PREFIX);
+    /// assert_eq!(NETWORK.unwrap().prefix(), PREFIX);
     /// ```
     pub const fn new_checked(addr: Ipv6Addr, prefix: u8) -> Option<Ipv6Network> {
         if prefix > IPV6_BITS {

--- a/src/ipv6.rs
+++ b/src/ipv6.rs
@@ -100,8 +100,8 @@ impl Ipv6Network {
     /// const ADDR: Ipv6Addr = Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 0);
     ///
     /// // Okay!
-    /// const NETWORK: Option<Ipv6Network> = Ipv6Network::new_checked(ADDR, PREFIX);
-    /// assert_eq!(NETWORK.unwrap().prefix(), PREFIX);
+    /// const NETWORK: Ipv6Network = Ipv6Network::new_checked(ADDR, PREFIX).unwrap();
+    /// assert_eq!(NETWORK.prefix(), PREFIX);
     /// ```
     ///
     /// ```should_panic

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 #![crate_type = "lib"]
 #![deny(
     missing_debug_implementations,
+    unsafe_code,
     unused_extern_crates,
     unused_import_braces
 )]


### PR DESCRIPTION
This PR implements one of the implementations proposed in https://github.com/achanda/ipnetwork/issues/202. It replaces the unsafe `Ipv4Network::new_unchecked` and `Ipv6Network::new_unchecked` functions with safe, checked versions without losing the original utility in `const` contexts. This change effectively enforces an MSRV of 1.83.