### PR TITLE
Make `IpNetwork::mask` const

### DIFF
--- a/src/ipv4.rs
+++ b/src/ipv4.rs
@@ -180,13 +180,13 @@ impl Ipv4Network {
     /// let net: Ipv4Network = "127.0.0.0/16".parse().unwrap();
     /// assert_eq!(net.mask(), Ipv4Addr::new(255, 255, 0, 0));
     /// ```
-    pub fn mask(&self) -> Ipv4Addr {
+    pub const fn mask(&self) -> Ipv4Addr {
         debug_assert!(self.prefix <= 32);
         if self.prefix == 0 {
             return Ipv4Addr::new(0, 0, 0, 0);
         }
         let mask = u32::MAX << (IPV4_BITS - self.prefix);
-        Ipv4Addr::from(mask)
+        Ipv4Addr::from_bits(mask)
     }
 
     /// Returns the address of the network denoted by this `Ipv4Network`.

--- a/src/ipv6.rs
+++ b/src/ipv6.rs
@@ -200,14 +200,14 @@ impl Ipv6Network {
     /// let net: Ipv6Network = "ff01::0/32".parse().unwrap();
     /// assert_eq!(net.mask(), Ipv6Addr::new(0xffff, 0xffff, 0, 0, 0, 0, 0, 0));
     /// ```
-    pub fn mask(&self) -> Ipv6Addr {
+    pub const fn mask(&self) -> Ipv6Addr {
         debug_assert!(self.prefix <= IPV6_BITS);
 
         if self.prefix == 0 {
             return Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0);
         }
         let mask = u128::MAX << (IPV6_BITS - self.prefix);
-        Ipv6Addr::from(mask)
+        Ipv6Addr::from_bits(mask)
     }
 
     /// Returns the address of the network denoted by this `Ipv6Network`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -226,7 +226,7 @@ impl IpNetwork {
     /// let v6_net: IpNetwork = "ff01::0/32".parse().unwrap();
     /// assert_eq!(v6_net.mask(), Ipv6Addr::new(0xffff, 0xffff, 0, 0, 0, 0, 0, 0));
     /// ```
-    pub fn mask(&self) -> IpAddr {
+    pub const fn mask(&self) -> IpAddr {
         match *self {
             IpNetwork::V4(ref a) => IpAddr::V4(a.mask()),
             IpNetwork::V6(ref a) => IpAddr::V6(a.mask()),


### PR DESCRIPTION
This PR makes `IpNetwork::mask` and thereby `Ipv4Network::mask` and `Ipv6Network::mask` const.

Is this too invasive? `Ipv{4,6}Addr::from_bits` was introduced in Rust 1.80. If this change was to be accepted, it would unlock more const-ification through `Ipv{4,6}Addr::to_bits` as well!