### PR TITLE
Make `IpNetwork::contains` const

### DIFF
--- a/src/ipv4.rs
+++ b/src/ipv4.rs
@@ -238,12 +238,12 @@ impl Ipv4Network {
     /// assert!(!net.contains(Ipv4Addr::new(127, 0, 1, 70)));
     /// ```
     #[inline]
-    pub fn contains(&self, ip: Ipv4Addr) -> bool {
+    pub const fn contains(&self, ip: Ipv4Addr) -> bool {
         debug_assert!(self.prefix <= IPV4_BITS);
 
         let mask = !(0xffff_ffff_u64 >> self.prefix) as u32;
-        let net = u32::from(self.addr) & mask;
-        (u32::from(ip) & mask) == net
+        let net = self.addr.to_bits() & mask;
+        (ip.to_bits() & mask) == net
     }
 
     /// Returns number of possible host addresses in this `Ipv4Network`.

--- a/src/ipv6.rs
+++ b/src/ipv6.rs
@@ -222,10 +222,10 @@ impl Ipv6Network {
     /// let net: Ipv6Network = "2001:db8::/96".parse().unwrap();
     /// assert_eq!(net.network(), Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 0));
     /// ```
-    pub fn network(&self) -> Ipv6Addr {
-        let mask = u128::from(self.mask());
-        let network = u128::from(self.addr) & mask;
-        Ipv6Addr::from(network)
+    pub const fn network(&self) -> Ipv6Addr {
+        let mask = self.mask().to_bits();
+        let network = self.addr.to_bits() & mask;
+        Ipv6Addr::from_bits(network)
     }
 
     /// Returns the broadcast address of this `Ipv6Network`.
@@ -259,10 +259,10 @@ impl Ipv6Network {
     /// assert!(!net.contains(Ipv6Addr::new(0xffff, 0, 0, 0, 0, 0, 0, 0x1)));
     /// ```
     #[inline]
-    pub fn contains(&self, ip: Ipv6Addr) -> bool {
-        let ip = u128::from(ip);
-        let net = u128::from(self.network());
-        let mask = u128::from(self.mask());
+    pub const fn contains(&self, ip: Ipv6Addr) -> bool {
+        let ip = ip.to_bits();
+        let net = self.network().to_bits();
+        let mask = self.mask().to_bits();
         (ip & mask) == net
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -292,7 +292,7 @@ impl IpNetwork {
     /// assert!(!net.contains(ip4));
     /// ```
     #[inline]
-    pub fn contains(&self, ip: IpAddr) -> bool {
+    pub const fn contains(&self, ip: IpAddr) -> bool {
         match (*self, ip) {
             (IpNetwork::V4(net), IpAddr::V4(ip)) => net.contains(ip),
             (IpNetwork::V6(net), IpAddr::V6(ip)) => net.contains(ip),


### PR DESCRIPTION
Following up on https://github.com/achanda/ipnetwork/pull/207, this PR makes `IpNetwork::contains` and thereby `Ipv4Network::contains` and `Ipv6Network::contains` const.

Should this const-ification be tracked in an issue, or is it fine to just keep these patches coming? :blush: