### PR TITLE
Make `IpNetwork::ip` const

### DIFF
--- a/src/ipv4.rs
+++ b/src/ipv4.rs
@@ -140,7 +140,7 @@ impl Ipv4Network {
         }
     }
 
-    pub fn ip(self) -> Ipv4Addr {
+    pub const fn ip(self) -> Ipv4Addr {
         self.addr
     }
 

--- a/src/ipv6.rs
+++ b/src/ipv6.rs
@@ -160,7 +160,7 @@ impl Ipv6Network {
         }
     }
 
-    pub fn ip(&self) -> Ipv6Addr {
+    pub const fn ip(&self) -> Ipv6Addr {
         self.addr
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,7 +141,7 @@ impl IpNetwork {
     }
 
     /// Returns the IP part of a given `IpNetwork`
-    pub fn ip(&self) -> IpAddr {
+    pub const fn ip(&self) -> IpAddr {
         match *self {
             IpNetwork::V4(ref a) => IpAddr::V4(a.ip()),
             IpNetwork::V6(ref a) => IpAddr::V6(a.ip()),


### PR DESCRIPTION
This PR makes `IpNetwork::ip` const.