### PR TITLE
Add `ip_mask_to_prefix_checked`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,9 +16,9 @@ mod ipv6;
 mod parse;
 mod size;
 
-pub use crate::error::{NetworkSizeError, IpNetworkError};
+pub use crate::error::{IpNetworkError, NetworkSizeError};
 pub use crate::ipv4::Ipv4NetworkIterator;
-pub use crate::ipv4::{ipv4_mask_to_prefix, Ipv4Network};
+pub use crate::ipv4::{ipv4_mask_to_prefix, ipv4_mask_to_prefix_checked, Ipv4Network};
 pub use crate::ipv6::Ipv6NetworkIterator;
 pub use crate::ipv6::{ipv6_mask_to_prefix, Ipv6Network};
 pub use crate::size::NetworkSize;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ pub use crate::error::{IpNetworkError, NetworkSizeError};
 pub use crate::ipv4::Ipv4NetworkIterator;
 pub use crate::ipv4::{ipv4_mask_to_prefix, ipv4_mask_to_prefix_checked, Ipv4Network};
 pub use crate::ipv6::Ipv6NetworkIterator;
-pub use crate::ipv6::{ipv6_mask_to_prefix, Ipv6Network};
+pub use crate::ipv6::{ipv6_mask_to_prefix, ipv6_mask_to_prefix_checked, Ipv6Network};
 pub use crate::size::NetworkSize;
 
 /// Represents a generic network range. This type can have two variants:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -433,6 +433,17 @@ pub fn ip_mask_to_prefix(mask: IpAddr) -> Result<u8, IpNetworkError> {
     }
 }
 
+/// Converts a `IpAddr` network mask into a prefix.
+///
+/// If the mask is invalid this will return `None`. This is useful in const contexts where
+/// [`Option::unwrap`] may be called to trigger a compile-time error if the prefix is invalid.
+pub const fn ip_mask_to_prefix_checked(mask: IpAddr) -> Option<u8> {
+    match mask {
+        IpAddr::V4(mask) => ipv4_mask_to_prefix_checked(mask),
+        IpAddr::V6(mask) => ipv6_mask_to_prefix_checked(mask),
+    }
+}
+
 #[cfg(test)]
 mod test {
     #[test]


### PR DESCRIPTION
This PR adds some new public APIs: `ip_mask_to_prefix_checked`, `ipv4_mask_to_prefix_checked` and `ipv6_mask_to_prefix_checked`.

Like in https://github.com/achanda/ipnetwork/pull/203, the rationale for adding new functions that return an `Option` instead is so that user's may unwrap the result to trigger a compile-time error if anything is wrong.

An ugly wart of const is that the `for` construct is not yet available, which means that I had to fall back to using a `while` loop + loop variable for iteration in `ipv6_mask_to_prefix_checked`.

I understand if this change is a bit too much, as the const-ification now starts to enforce a coding style which feels a bit unidiomatic. Please, think this one through a bit and do come with feedback!

Edit: These APIs will allow us to add a const ditto of `IpNetwork::with_netmask` if we wish to do that, which is kind of nice :blush: