### PR TITLE
Add `rust-version` to `Cargo.toml` and set MSRV to 1.80

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ keywords = ["network", "ip", "address", "cidr"]
 readme = "README.md"
 categories = ["network-programming", "parser-implementations"]
 edition = "2021"
+rust-version = "1.80.0"
 
 [dependencies]
 serde = { version = "1.0.200", optional = true }


### PR DESCRIPTION
With the [stabilization of the MSRV aware resolver in Rust 1.84](https://blog.rust-lang.org/2025/01/09/Rust-1.84.0.html#cargo-considers-rust-versions-for-dependency-version-selection), I think it is good courtesy to [explicitly define the MSRV](https://doc.rust-lang.org/cargo/reference/rust-version.html) of this crate. The new resolver will actually be enabled by default in the 2024 edition!

In https://github.com/achanda/ipnetwork/pull/207, the MSRV was bumped to 1.80 :blush: