### PR TITLE
Iterator size hints

### DIFF
--- a/src/ipv4.rs
+++ b/src/ipv4.rs
@@ -368,6 +368,15 @@ impl Iterator for Ipv4NetworkIterator {
         };
         Some(next.into())
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        if let Some(n) = self.next {
+            let elms = (self.end - n + 1) as usize;
+            (elms, Some(elms))
+        } else {
+            (0, None)
+        }
+    }
 }
 
 impl IntoIterator for &'_ Ipv4Network {
@@ -580,6 +589,25 @@ mod test {
             assert_eq!(i as u32, u32::from(iter.next().unwrap()));
         }
         assert_eq!(None, iter.next());
+    }
+
+    #[test]
+    fn iterator_v4_size_hint() {
+        let cidr: Ipv4Network = "192.168.0.0/24".parse().unwrap();
+        let mut iter = cidr.iter();
+        assert_eq!((256, Some(256)), iter.size_hint());
+        iter.next();
+        assert_eq!((255, Some(255)), iter.size_hint());
+
+        let cidr: Ipv4Network = "192.168.0.0/32".parse().unwrap();
+        let mut iter = cidr.iter();
+        assert_eq!((1, Some(1)), iter.size_hint());
+        iter.next();
+        assert_eq!((0, None), iter.size_hint());
+
+        let cidr: Ipv4Network = "192.168.0.0/0".parse().unwrap();
+        let iter = cidr.iter();
+        assert_eq!((4294967295, Some(4294967295)), iter.size_hint());
     }
 
     #[test]

--- a/src/ipv6.rs
+++ b/src/ipv6.rs
@@ -372,6 +372,15 @@ impl Iterator for Ipv6NetworkIterator {
         };
         Some(next.into())
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        if let Some(n) = self.next {
+            let elms = (self.end - n + 1) as usize;
+            (elms, Some(elms))
+        } else {
+            (0, None)
+        }
+    }
 }
 
 impl IntoIterator for &'_ Ipv6Network {
@@ -610,6 +619,18 @@ mod test {
         assert_eq!(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 0), iter.next().unwrap());
         assert_eq!(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1), iter.next().unwrap());
         assert_eq!(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 2), iter.next().unwrap());
+    }
+
+    #[test]
+    fn iterator_v6_size_hint() {
+        let cidr: Ipv6Network = "2001:db8::/128".parse().unwrap();
+        let mut iter = cidr.iter();
+        assert_eq!((1, Some(1)), iter.size_hint());
+        assert_eq!(
+            Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0, 0, 0),
+            iter.next().unwrap()
+        );
+        assert_eq!((0, None), iter.size_hint());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -414,6 +414,12 @@ impl Iterator for IpNetworkIterator {
             IpNetworkIteratorInner::V6(iter) => iter.next().map(IpAddr::V6),
         }
     }
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        match &self.inner {
+            IpNetworkIteratorInner::V4(iter) => iter.size_hint(),
+            IpNetworkIteratorInner::V6(iter) => iter.size_hint(),
+        }
+    }
 }
 
 impl IntoIterator for &'_ IpNetwork {


### PR DESCRIPTION
Adding size hints can be helpful for something like `.choose()` for picking an IP at random in a range